### PR TITLE
Add verify property to get_username get request

### DIFF
--- a/scigateway-auth/src/auth.py
+++ b/scigateway-auth/src/auth.py
@@ -46,7 +46,7 @@ class ICATAuthenticator(object):
         """
         log.info(
             f"Retrieving username for session id {session_id} at {ICAT_URL}")
-        response = requests.get(f"{ICAT_URL}/session/{session_id}")
+        response = requests.get(f"{ICAT_URL}/session/{session_id}", verify=VERIFY)
         if response.status_code is 200:
             return response.json()["userName"]
         else:


### PR DESCRIPTION
It seems when developing the two branches of adding certificate verification configuration and ICAT username info that the two didn't consider each other and therefore we get errors when running the master branch due to certificate verification failures on preprod.