### PR TITLE
Fix timezone issue

### DIFF
--- a/src/auth.py
+++ b/src/auth.py
@@ -13,7 +13,7 @@ import datetime
 
 
 def current_time():
-    return datetime.datetime.now()
+    return datetime.datetime.now(datetime.timezone.utc)
 
 
 log = logging.getLogger()


### PR DESCRIPTION
Fixes an issue in that `datetime.now()` by default has no timestamp information attached, and assumes local timezone of the machine but when our JWT library converts to UNIX time it assumes UTC timezone. This is fixed by manually specifying the timezone in `datetime.now()`, and fixes the issues with tokens living longer than ICAT sessions are alive, despite the times being "correct" in the settings files.