### PR TITLE
Add templates and workflow for CI #51

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,6 @@
+**Description**:
+Add a description here
+
+**Acceptance criteria**:
+- [ ] A checklist
+- [ ] of criteria to accept this story as done

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+This PR will close #{issue number}
+
+## Description
+Enter a description of the changes here
+
+## Testing Instructions
+Add a set up instructions describing how the reviewer should test the code
+
+- [ ] Review code
+- [ ] Check GitHub Actions build
+- [ ] Review changes to test coverage
+- [ ] {more steps here}
+
+## Agile Board Tracking
+Connect to #{issue number}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -51,8 +51,6 @@ jobs:
     - name: Upload code coverage report
       if: matrix.python-version == '3.6'
       uses: codecov/codecov-action@v1
-      with:
-        directory: ./scigateway-auth
 
   linting:
     runs-on: ubuntu-16.04

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,0 +1,115 @@
+name: CI
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - master
+jobs:
+  tests:
+    runs-on: ubuntu-16.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.6', '3.7', '3.8', '3.9']
+    name: Python ${{ matrix.python-version }} Build & Tests
+    steps:
+    - name: Add apt repo
+      run: sudo add-apt-repository universe
+
+    # Setup Python
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: x64
+
+    # Checkout repo
+    - name: Checkout repo
+      uses: actions/checkout@v2
+
+    # Prep for the tests
+    - name: Create log file
+      run: touch logs.log
+    - name: Configure log file location
+      run: echo "`jq -r --arg REPO_DIR "$GITHUB_WORKSPACE/logs.log" \
+        '.log_location=$REPO_DIR' scigateway-auth/scigateway_auth/config.json.example`" > scigateway-auth/scigateway_auth/config.json.example
+    - name: Create config.json
+      run: cp scigateway-auth/scigateway_auth/config.json.example scigateway-auth/scigateway_auth/config.json
+
+    # Install Nox, Poetry and API's dependencies
+    - name: Install Nox
+      run: pip install nox==2020.8.22
+    - name: Install Poetry
+      run: pip install poetry==1.1.4
+    - name: Install dependencies
+      run: cd scigateway-auth/ && poetry install
+
+    # Run Nox tests session, saves and uploads a coverage report to codecov
+    - name: Run Nox tests session
+      run: nox -s tests -f scigateway-auth/noxfile.py -- --cov=scigateway_auth --cov-report=xml
+    - name: Upload code coverage report
+      if: matrix.python-version == '3.6'
+      uses: codecov/codecov-action@v1
+      with:
+        directory: ./scigateway-auth
+
+  linting:
+    runs-on: ubuntu-16.04
+    name: Linting
+    steps:
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.6'
+        architecture: x64
+    - name: Checkout repo
+      uses: actions/checkout@v2
+
+    - name: Install Nox
+      run: pip install nox==2020.8.22
+    - name: Install Poetry
+      run: pip install poetry==1.1.4
+
+    - name: Run Nox lint session
+      run: nox -s lint -f scigateway-auth/noxfile.py
+
+  formatting:
+    runs-on: ubuntu-16.04
+    name: Code Formatting
+    steps:
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.6'
+        architecture: x64
+    - name: Checkout repo
+      uses: actions/checkout@v2
+
+    - name: Install Nox
+      run: pip install nox==2020.8.22
+    - name: Install Poetry
+      run: pip install poetry==1.1.4
+
+    - name: Run Nox black session
+      run: nox -s black -f scigateway-auth/noxfile.py
+
+  safety:
+    runs-on: ubuntu-16.04
+    name: Dependency Safety
+    steps:
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.6'
+        architecture: x64
+    - name: Checkout repo
+      uses: actions/checkout@v2
+
+    - name: Install Nox
+      run: pip install nox==2020.8.22
+    - name: Install Poetry
+      run: pip install poetry==1.1.4
+
+    - name: Run Nox safety session
+      run: nox -s safety -f scigateway-auth/noxfile.py

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -35,7 +35,7 @@ jobs:
       run: echo "`jq -r --arg REPO_DIR "$GITHUB_WORKSPACE/logs.log" \
         '.log_location=$REPO_DIR' scigateway_auth/config.json.example`" > scigateway_auth/config.json.example
     - name: Create config.json
-      run: cp sscigateway_auth/config.json.example scigateway_auth/config.json
+      run: cp scigateway_auth/config.json.example scigateway_auth/config.json
 
     # Install Nox, Poetry and API's dependencies
     - name: Install Nox

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -33,9 +33,9 @@ jobs:
       run: touch logs.log
     - name: Configure log file location
       run: echo "`jq -r --arg REPO_DIR "$GITHUB_WORKSPACE/logs.log" \
-        '.log_location=$REPO_DIR' scigateway-auth/scigateway_auth/config.json.example`" > scigateway-auth/scigateway_auth/config.json.example
+        '.log_location=$REPO_DIR' scigateway_auth/config.json.example`" > scigateway_auth/config.json.example
     - name: Create config.json
-      run: cp scigateway-auth/scigateway_auth/config.json.example scigateway-auth/scigateway_auth/config.json
+      run: cp sscigateway_auth/config.json.example scigateway_auth/config.json
 
     # Install Nox, Poetry and API's dependencies
     - name: Install Nox
@@ -43,7 +43,7 @@ jobs:
     - name: Install Poetry
       run: pip install poetry==1.1.4
     - name: Install dependencies
-      run: cd scigateway-auth/ && poetry install
+      run: poetry install
 
     # Run Nox tests session, saves and uploads a coverage report to codecov
     - name: Run Nox tests session

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -47,7 +47,7 @@ jobs:
 
     # Run Nox tests session, saves and uploads a coverage report to codecov
     - name: Run Nox tests session
-      run: nox -s tests -f scigateway-auth/noxfile.py -- --cov=scigateway_auth --cov-report=xml
+      run: nox -s tests -- --cov=scigateway_auth --cov-report=xml
     - name: Upload code coverage report
       if: matrix.python-version == '3.6'
       uses: codecov/codecov-action@v1
@@ -72,7 +72,7 @@ jobs:
       run: pip install poetry==1.1.4
 
     - name: Run Nox lint session
-      run: nox -s lint -f scigateway-auth/noxfile.py
+      run: nox -s lint
 
   formatting:
     runs-on: ubuntu-16.04
@@ -92,7 +92,7 @@ jobs:
       run: pip install poetry==1.1.4
 
     - name: Run Nox black session
-      run: nox -s black -f scigateway-auth/noxfile.py
+      run: nox -s black
 
   safety:
     runs-on: ubuntu-16.04
@@ -112,4 +112,4 @@ jobs:
       run: pip install poetry==1.1.4
 
     - name: Run Nox safety session
-      run: nox -s safety -f scigateway-auth/noxfile.py
+      run: nox -s safety

--- a/scigateway_auth/common/constants.py
+++ b/scigateway_auth/common/constants.py
@@ -1,10 +1,16 @@
 from scigateway_auth.common.config import config
 
-with open(config.get_private_key_path(), "r") as f:
-    PRIVATE_KEY = f.read()
+try:
+    with open(config.get_private_key_path(), "r") as f:
+        PRIVATE_KEY = f.read()
+except FileNotFoundError:
+    PRIVATE_KEY = ""
 
-with open(config.get_public_key_path(), "r") as f:
-    PUBLIC_KEY = f.read()
+try:
+    with open(config.get_public_key_path(), "r") as f:
+        PUBLIC_KEY = f.read()
+except FileNotFoundError:
+    PUBLIC_KEY = ""
 
 ICAT_URL = config.get_icat_url()
 ACCESS_TOKEN_VALID_FOR = config.get_access_token_valid_for()


### PR DESCRIPTION
## Description

- Have added templates for issues and PRs (same format as the other repos).
- Added a workflow that runs flake8, black, safety and tests in Python versions 3.6, 3.7, 3.8, 3.9
- Tried to add code coverage but I think an admin needs to add this repo to https://codecov.io/gh/ral-facilities ?
  - [ ] Enable CodeCov for this repo
- Except `FileNotFoundErrors` when loading `PRIVATE_KEY` and `PUBLIC_KEY`. Because these are loaded in `constants.py` but do not appear in the repo, the CI will try and fail to load them when running the test files. Catching these exceptions allows the tests to run successfully. We may want a more involved solution to this, but this is sufficient to get the GHA passing.

## Testing Instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] No changes to functionality expected

## Agile Board Tracking
Connect to #51