### PR TITLE
Tokens do not get blacklisted until the API is restarted

### DIFF
--- a/scigateway_auth/app.py
+++ b/scigateway_auth/app.py
@@ -6,7 +6,7 @@ if __name__ == "__main__":  # NOQA: E402
 
     constants.SECURE = False
 
-from scigateway_auth.common.config import config
+from scigateway_auth.common.config import Config, get_config_value
 from scigateway_auth.common.logger_setup import setup_logger
 from scigateway_auth.src.endpoints import (
     AuthenticatorsEndpoint,
@@ -32,7 +32,7 @@ api.add_resource(ScheduledMaintenanceEndpoint, "/scheduled_maintenance")
 
 if __name__ == "__main__":
     app.run(
-        host=config.get_host(),
-        port=config.get_port(),
-        debug=config.is_debug_mode(),
+        host=get_config_value(Config.HOST),
+        port=get_config_value(Config.PORT),
+        debug=get_config_value(Config.DEBUG_MODE),
     )

--- a/scigateway_auth/common/config.py
+++ b/scigateway_auth/common/config.py
@@ -1,103 +1,50 @@
+from enum import Enum
 import json
 from pathlib import Path
 import sys
 
 
-class Config(object):
-    def __init__(self):
+class Config(Enum):
+    HOST = "host"
+    PORT = "port"
+    DEBUG_MODE = "debug_mode"
+    ICAT_URL = "icat_url"
+    LOG_LEVEL = "log_level"
+    LOG_LOCATION = "log_location"
+    PRIVATE_KEY_PATH = "private_key_path"
+    PUBLIC_KEY_PATH = "public_key_path"
+    ACCESS_TOKEN_VALID_FOR = "access_token_valid_for"  # noqa: S105
+    REFRESH_TOKEN_VALID_FOR = "refresh_token_valid_for"  # noqa: S105
+    BLACKLIST = "blacklist"
+    ADMIN_USERS = "admin_users"
+    MAINTENANCE_CONFIG_PATH = "maintenance_config_path"
+    SCHEDULED_MAINTENANCE_CONFIG_PATH = "scheduled_maintenance_config_path"
+    VERIFY = "verify"
+
+
+def _load_config():
+    """
+    Loads config values from the JSON config file. Exits the application if it
+    fails to locate/ read the contents of the file.
+    :return: config values in form of a dictionary
+    """
+    try:
         with open(Path(__file__).parent.parent / "config.json") as target:
-            self.config = json.load(target)
-        target.close()
-
-    def get_host(self):
-        try:
-            return self.config["host"]
-        except KeyError:
-            sys.exit("Missing config value: host")
-
-    def get_port(self):
-        try:
-            return self.config["port"]
-        except KeyError:
-            sys.exit("Missing config value: port")
-
-    def is_debug_mode(self):
-        try:
-            return self.config["debug_mode"]
-        except KeyError:
-            sys.exit("Missing config value: debug_mode")
-
-    def get_icat_url(self):
-        try:
-            return self.config["icat_url"]
-        except KeyError:
-            sys.exit("Missing config value: icat_url")
-
-    def get_log_level(self):
-        try:
-            return self.config["log_level"]
-        except KeyError:
-            sys.exit("Missing config value, log_level")
-
-    def get_log_location(self):
-        try:
-            return self.config["log_location"]
-        except KeyError:
-            sys.exit("Missing config value, log_location")
-
-    def get_private_key_path(self):
-        try:
-            return self.config["private_key_path"]
-        except KeyError:
-            sys.exit("Missing config value, private_key_path")
-
-    def get_public_key_path(self):
-        try:
-            return self.config["public_key_path"]
-        except KeyError:
-            sys.exit("Missing config value, public_key_path")
-
-    def get_access_token_valid_for(self):
-        try:
-            return self.config["access_token_valid_for"]
-        except KeyError:
-            sys.exit("Missing config value, access_token_valid_for")
-
-    def get_refresh_token_valid_for(self):
-        try:
-            return self.config["refresh_token_valid_for"]
-        except KeyError:
-            sys.exit("Missing config value, refresh_token_valid_for")
-
-    def get_blacklist(self):
-        try:
-            return self.config["blacklist"]
-        except KeyError:
-            sys.exit("Missing config value, blacklist")
-
-    def get_admin_users(self):
-        try:
-            return self.config["admin_users"]
-        except KeyError:
-            sys.exit("Missing config value, admin_users")
-
-    def get_maintenance_config_path(self):
-        try:
-            return self.config["maintenance_config_path"]
-        except KeyError:
-            sys.exit("Missing config value, maintenance_config_path")
-
-    def get_scheduled_maintenance_config_path(self):
-        try:
-            return self.config["scheduled_maintenance_config_path"]
-        except KeyError:
-            sys.exit("Missing config value, scheduled_maintenance_config_path")
-
-    def get_verify(self):
-        try:
-            return self.config["verify"]
-        except KeyError:
-            sys.exit("Missing config value, verify")
+            return json.load(target)
+    except IOError:
+        sys.exit("Error loading config file")
 
 
-config = Config()
+def get_config_value(config):
+    """
+    Given a Config enum, it returns a config value. Reloads the values from the
+    config file so that a restart of the application is not required for config
+    changes to take effect. Exits the application if the provided enum is not in
+    the config dictionary.
+    :return: config value
+    """
+    config_values = _load_config()
+    try:
+        return config_values[config.value]
+    except KeyError:
+        sys.exit("Missing config value, %s" % config.value)

--- a/scigateway_auth/common/constants.py
+++ b/scigateway_auth/common/constants.py
@@ -1,23 +1,25 @@
-from scigateway_auth.common.config import config
+from scigateway_auth.common.config import Config, get_config_value
 
 try:
-    with open(config.get_private_key_path(), "r") as f:
+    with open(get_config_value(Config.PRIVATE_KEY_PATH), "r") as f:
         PRIVATE_KEY = f.read()
 except FileNotFoundError:
     PRIVATE_KEY = ""
 
 try:
-    with open(config.get_public_key_path(), "r") as f:
+    with open(get_config_value(Config.PUBLIC_KEY_PATH), "r") as f:
         PUBLIC_KEY = f.read()
 except FileNotFoundError:
     PUBLIC_KEY = ""
 
-ICAT_URL = config.get_icat_url()
-ACCESS_TOKEN_VALID_FOR = config.get_access_token_valid_for()
-REFRESH_TOKEN_VALID_FOR = config.get_refresh_token_valid_for()
-BLACKLIST = config.get_blacklist()
-ADMIN_USERS = config.get_admin_users()
-MAINTENANCE_CONFIG_PATH = config.get_maintenance_config_path()
-SCHEDULED_MAINTENANCE_CONFIG_PATH = config.get_scheduled_maintenance_config_path()
+ICAT_URL = get_config_value(Config.ICAT_URL)
+ACCESS_TOKEN_VALID_FOR = get_config_value(Config.ACCESS_TOKEN_VALID_FOR)
+REFRESH_TOKEN_VALID_FOR = get_config_value(Config.REFRESH_TOKEN_VALID_FOR)
+BLACKLIST = get_config_value(Config.BLACKLIST)
+ADMIN_USERS = get_config_value(Config.ADMIN_USERS)
+MAINTENANCE_CONFIG_PATH = get_config_value(Config.MAINTENANCE_CONFIG_PATH)
+SCHEDULED_MAINTENANCE_CONFIG_PATH = get_config_value(
+    Config.SCHEDULED_MAINTENANCE_CONFIG_PATH,
+)
 SECURE = True
-VERIFY = config.get_verify()
+VERIFY = get_config_value(Config.VERIFY)

--- a/scigateway_auth/common/constants.py
+++ b/scigateway_auth/common/constants.py
@@ -15,7 +15,6 @@ except FileNotFoundError:
 ICAT_URL = get_config_value(Config.ICAT_URL)
 ACCESS_TOKEN_VALID_FOR = get_config_value(Config.ACCESS_TOKEN_VALID_FOR)
 REFRESH_TOKEN_VALID_FOR = get_config_value(Config.REFRESH_TOKEN_VALID_FOR)
-BLACKLIST = get_config_value(Config.BLACKLIST)
 ADMIN_USERS = get_config_value(Config.ADMIN_USERS)
 MAINTENANCE_CONFIG_PATH = get_config_value(Config.MAINTENANCE_CONFIG_PATH)
 SCHEDULED_MAINTENANCE_CONFIG_PATH = get_config_value(

--- a/scigateway_auth/common/constants.py
+++ b/scigateway_auth/common/constants.py
@@ -15,7 +15,6 @@ except FileNotFoundError:
 ICAT_URL = get_config_value(Config.ICAT_URL)
 ACCESS_TOKEN_VALID_FOR = get_config_value(Config.ACCESS_TOKEN_VALID_FOR)
 REFRESH_TOKEN_VALID_FOR = get_config_value(Config.REFRESH_TOKEN_VALID_FOR)
-ADMIN_USERS = get_config_value(Config.ADMIN_USERS)
 MAINTENANCE_CONFIG_PATH = get_config_value(Config.MAINTENANCE_CONFIG_PATH)
 SCHEDULED_MAINTENANCE_CONFIG_PATH = get_config_value(
     Config.SCHEDULED_MAINTENANCE_CONFIG_PATH,

--- a/scigateway_auth/common/logger_setup.py
+++ b/scigateway_auth/common/logger_setup.py
@@ -1,6 +1,6 @@
 import logging.config
 
-from scigateway_auth.common.config import config
+from scigateway_auth.common.config import Config, get_config_value
 
 logger_config = {
     "version": 1,
@@ -12,15 +12,15 @@ logger_config = {
     },
     "handlers": {
         "default": {
-            "level": config.get_log_level(),
+            "level": get_config_value(Config.LOG_LEVEL),
             "formatter": "default",
             "class": "logging.handlers.RotatingFileHandler",
-            "filename": config.get_log_location(),
+            "filename": get_config_value(Config.LOG_LOCATION),
             "maxBytes": 5000000,
             "backupCount": 10,
         },
     },
-    "root": {"level": config.get_log_level(), "handlers": ["default"]},
+    "root": {"level": get_config_value(Config.LOG_LEVEL), "handlers": ["default"]},
 }
 
 

--- a/scigateway_auth/src/admin.py
+++ b/scigateway_auth/src/admin.py
@@ -3,8 +3,8 @@ import logging
 
 import jwt
 
+from scigateway_auth.common.config import Config, get_config_value
 from scigateway_auth.common.constants import (
-    BLACKLIST,
     MAINTENANCE_CONFIG_PATH,
     PUBLIC_KEY,
     SCHEDULED_MAINTENANCE_CONFIG_PATH,
@@ -129,7 +129,7 @@ def _verify_token(token):
     """
     log.info("Verifying token")
     jwt.decode(token, PUBLIC_KEY, algorithms=["RS256"])
-    if token in BLACKLIST:
+    if token in get_config_value(Config.BLACKLIST):
         log.warning("Token in blacklist: %s", token)
         raise Exception("Token in blacklist")
     log.info("Token verified")

--- a/scigateway_auth/src/auth.py
+++ b/scigateway_auth/src/auth.py
@@ -6,10 +6,10 @@ import logging
 import jwt
 import requests
 
+from scigateway_auth.common.config import Config, get_config_value
 from scigateway_auth.common.constants import (
     ACCESS_TOKEN_VALID_FOR,
     ADMIN_USERS,
-    BLACKLIST,
     ICAT_URL,
     PRIVATE_KEY,
     PUBLIC_KEY,
@@ -181,7 +181,7 @@ class AuthenticationHandler(object):
         try:
             log.info("Refreshing token")
             jwt.decode(refresh_token, PUBLIC_KEY, algorithms=["RS256"])
-            if refresh_token in BLACKLIST:
+            if refresh_token in get_config_value(Config.BLACKLIST):
                 log.warning(
                     "Attempted refresh from token in blacklist: %s",
                     refresh_token,

--- a/scigateway_auth/src/auth.py
+++ b/scigateway_auth/src/auth.py
@@ -9,7 +9,6 @@ import requests
 from scigateway_auth.common.config import Config, get_config_value
 from scigateway_auth.common.constants import (
     ACCESS_TOKEN_VALID_FOR,
-    ADMIN_USERS,
     ICAT_URL,
     PRIVATE_KEY,
     PUBLIC_KEY,
@@ -114,7 +113,7 @@ class AuthenticationHandler(object):
             credentials=self.credentials,
         )
         username = authenticator.get_username(session_id)
-        user_is_admin = username in ADMIN_USERS
+        user_is_admin = username in get_config_value(Config.ADMIN_USERS)
         return {
             "sessionId": session_id,
             "username": username,

--- a/test/test_authenticationHandler.py
+++ b/test/test_authenticationHandler.py
@@ -57,6 +57,11 @@ def mock_get_blacklist_with_tokens(*args, **kwargs):
         return [VALID_REFRESH_TOKEN]
 
 
+def mock_get_admin_users(*args, **kwargs):
+    if args[0] is Config.ADMIN_USERS:
+        return ["test name"]
+
+
 @mock.patch("scigateway_auth.src.auth.ACCESS_TOKEN_VALID_FOR", 5)
 @mock.patch("scigateway_auth.src.auth.REFRESH_TOKEN_VALID_FOR", 10080)
 @mock.patch("scigateway_auth.src.auth.PRIVATE_KEY", PRIVATE_KEY)
@@ -85,8 +90,17 @@ class TestAuthenticationHandler(TestCase):
     @mock.patch("requests.post", side_effect=mock_post_requests)
     @mock.patch("requests.get", side_effect=mock_get_requests)
     @mock.patch("scigateway_auth.src.auth.current_time", side_effect=mock_datetime_now)
-    @mock.patch("scigateway_auth.src.auth.ADMIN_USERS", ["test name"])
-    def test_get_access_token_admin_user(self, mock_post, mock_get, mock_now):
+    @mock.patch(
+        "scigateway_auth.src.auth.get_config_value",
+        side_effect=mock_get_admin_users,
+    )
+    def test_get_access_token_admin_user(
+        self,
+        mock_post,
+        mock_get,
+        mock_now,
+        mock_admin_users,
+    ):
         self.handler.set_mnemonic("anon")
         token = self.handler.get_access_token()
         expected_token = REFRESHED_ACCESS_TOKEN

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,0 +1,28 @@
+import json
+from unittest import mock, TestCase
+
+from scigateway_auth.common.config import _load_config, Config, get_config_value
+
+CONFIG_VALUES = {"verify": True}
+
+
+@mock.patch(
+    "builtins.open",
+    mock.mock_open(read_data=json.dumps(CONFIG_VALUES)),
+)
+class TestConfig(TestCase):
+    def test__load_config(self):
+        self.assertEqual(_load_config(), CONFIG_VALUES)
+
+    def test__load_config_failure(self):
+        with mock.patch("builtins.open", mock.mock_open()) as mocked_file:
+            mocked_file.side_effect = IOError()
+            with self.assertRaises(SystemExit):
+                _load_config()
+
+    def test_get_config_value(self):
+        self.assertEqual(get_config_value(Config.VERIFY), True)
+
+    def test_get_config_value_missing(self):
+        with self.assertRaises(SystemExit):
+            get_config_value(Config.BLACKLIST)

--- a/test/test_scheduled_maintenance_mode.py
+++ b/test/test_scheduled_maintenance_mode.py
@@ -1,6 +1,7 @@
 import json
 from unittest import mock, TestCase
 
+from scigateway_auth.common.config import Config
 from scigateway_auth.src import admin
 from scigateway_auth.src.admin import ScheduledMaintenanceMode
 from test.testutils import (
@@ -16,6 +17,16 @@ from test.testutils import (
 
 SCHEDULED_MAINTENANCE_STATE = MAINTENANCE_STATE
 SCHEDULED_MAINTENANCE_CONFIG_PATH = MAINTENANCE_CONFIG_PATH
+
+
+def mock_get_blacklist_with_tokens(*args, **kwargs):
+    if args[0] is Config.BLACKLIST:
+        return [VALID_ACCESS_TOKEN]
+
+
+def mock_get_blacklist_no_tokens(*args, **kwargs):
+    if args[0] is Config.BLACKLIST:
+        return []
 
 
 @mock.patch("scigateway_auth.src.admin.PUBLIC_KEY", PUBLIC_KEY)
@@ -37,7 +48,11 @@ class TestScheduledMaintenanceMode(TestCase):
             SCHEDULED_MAINTENANCE_STATE,
         )
 
-    def test_set_state_valid_token(self):
+    @mock.patch(
+        "scigateway_auth.src.admin.get_config_value",
+        side_effect=mock_get_blacklist_no_tokens,
+    )
+    def test_set_state_valid_token(self, mock_blacklist):
         mock_json_dump = mock.patch.object(admin.json, "dump").start()
         with mock.patch("builtins.open", mock.mock_open()) as mocked_file:
             result = self.scheduled_maintenance_mode.set_state(
@@ -69,8 +84,11 @@ class TestScheduledMaintenanceMode(TestCase):
         )
         self.assertEqual(result, ("Access token was not valid", 403))
 
-    @mock.patch("scigateway_auth.src.admin.BLACKLIST", [VALID_ACCESS_TOKEN])
-    def test_set_state_blacklisted_token(self):
+    @mock.patch(
+        "scigateway_auth.src.admin.get_config_value",
+        side_effect=mock_get_blacklist_with_tokens,
+    )
+    def test_set_state_blacklisted_token(self, mock_blacklist):
         result = self.scheduled_maintenance_mode.set_state(
             VALID_ACCESS_TOKEN,
             SCHEDULED_MAINTENANCE_STATE,
@@ -91,7 +109,11 @@ class TestScheduledMaintenanceMode(TestCase):
         )
         self.assertEqual(result, ("Unauthorized", 403))
 
-    def test_set_state_file_update_failure(self):
+    @mock.patch(
+        "scigateway_auth.src.admin.get_config_value",
+        side_effect=mock_get_blacklist_no_tokens,
+    )
+    def test_set_state_file_update_failure(self, mock_blacklist):
         with mock.patch("builtins.open", mock.mock_open()) as mocked_file:
             mocked_file.side_effect = IOError()
             result = self.scheduled_maintenance_mode.set_state(


### PR DESCRIPTION
## Description
As stated in the issue, adding a token to `blacklist` in the `config.json` file did not result in the token being immediately blacklisted. A restart of the application was required for this to take effect. While working to fix this, I also noticed that the same case is with the `admin_users` list.  The changes in this PR address these issues. Instead of creating constants for these two config values at runtime, the application is now reloading the values from the config when it checks whether a token is blacklisted/ user is in the admin list. 

I refactored the `config.py` module and wrote unit tests for its logic. The changes should not affect how the API works.

## Testing Instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] Review changes to test coverage
- [ ] Check that adding/ removing a token from `blacklist` in `config.json` while the API is running results in the token being recognised/ not recognised as blacklisted by the API.
- [ ] Check that adding/ removing a user from the `admin_users` list in `config.json` while the API is running results in the user being recognised/ not recognised as admin user by the API.

## Agile Board Tracking
Closes #62 
