### PR TITLE
Create Actions job for uploading container image to Harbor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "daily"

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -3,6 +3,7 @@ on:
   workflow_dispatch:
   pull_request:
   push:
+    # TODO - Change this to main before merging k8s-deployment into main
     branches:
       - k8s-deployment
 jobs:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - k8s-deployment
 jobs:
   tests:
     runs-on: ubuntu-20.04
@@ -111,3 +111,10 @@ jobs:
 
     - name: Run Nox safety session
       run: nox -s safety
+
+  docker:
+    name: Docker
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Check out repo
+      uses: actions/checkout@v2

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -132,3 +132,11 @@ jobs:
       uses: docker/metadata-action@v3
       with:
         images: harbor.stfc.ac.uk/datagateway/scigateway-auth
+
+    - name: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/deployment/push-docker-image-to-harbor-#70') && 'Build and push Docker image to Harbor' || 'Build Docker image' }}
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        push: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/deployment/push-docker-image-to-harbor-#70') }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -126,3 +126,9 @@ jobs:
         registry: harbor.stfc.ac.uk/datagateway
         username: ${{ secrets.HARBOR_USERNAME }}
         password: ${{ secrets.HARBOR_TOKEN }}
+
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@v3
+      with:
+        images: harbor.stfc.ac.uk/datagateway/scigateway-auth

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -134,10 +134,10 @@ jobs:
       with:
         images: harbor.stfc.ac.uk/datagateway/scigateway-auth
 
-    - name: ${{ github.event_name == 'push' && github.ref == 'refs/heads/deployment/push-docker-image-to-harbor-#70' && 'Build and push Docker image to Harbor' || 'Build Docker image' }}
+    - name: ${{ github.event_name == 'push' && github.ref == 'refs/heads/k8s-deployment' && 'Build and push Docker image to Harbor' || 'Build Docker image' }}
       uses: docker/build-push-action@v2
       with:
         context: .
-        push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/deployment/push-docker-image-to-harbor-#70' }}
+        push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/k8s-deployment' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -114,6 +114,9 @@ jobs:
       run: nox -s safety
 
   docker:
+    # This job triggers only if all the other jobs succeed and does different things depending on the context.
+    # The job builds the Docker image in all cases and also pushes the image to Harbor only if something is
+    # pushed to the k8s-deployment branch.
     needs: [tests, linting, formatting, safety]
     name: Docker
     runs-on: ubuntu-20.04
@@ -134,10 +137,12 @@ jobs:
       with:
         images: harbor.stfc.ac.uk/datagateway/scigateway-auth
 
+    # TODO - Change github.ref to refs/heads/main before merging k8s-deployment into main
     - name: ${{ github.event_name == 'push' && github.ref == 'refs/heads/k8s-deployment' && 'Build and push Docker image to Harbor' || 'Build Docker image' }}
       uses: docker/build-push-action@v2
       with:
         context: .
+        # TODO - Change github.ref to refs/heads/main before merging k8s-deployment into main
         push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/k8s-deployment' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -134,13 +134,6 @@ jobs:
       with:
         images: harbor.stfc.ac.uk/datagateway/scigateway-auth
 
-    - run: echo ${{github.event_name}}
-    - run: echo ${{github.ref}}
-    - run: echo ${{ (github.event_name == 'push' && github.ref == 'refs/heads/deployment/push-docker-image-to-harbor-#70') }}
-    - run: echo ${{ github.event_name == 'push' && github.ref == 'refs/heads/deployment/push-docker-image-to-harbor-#70' }}
-    - run: echo ${{ (github.event_name == 'push' && github.ref == 'refs/heads/deployment/push-docker-image-to-harbor-#70') && 'Build and push Docker image to Harbor' || 'Build Docker image' }}
-    - run: echo ${{ github.event_name == 'push' && github.ref == 'refs/heads/deployment/push-docker-image-to-harbor-#70' && 'Build and push Docker image to Harbor' || 'Build Docker image' }}
-
     - name: ${{ github.event_name == 'push' && github.ref == 'refs/heads/deployment/push-docker-image-to-harbor-#70' && 'Build and push Docker image to Harbor' || 'Build Docker image' }}
       uses: docker/build-push-action@v2
       with:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -134,10 +134,17 @@ jobs:
       with:
         images: harbor.stfc.ac.uk/datagateway/scigateway-auth
 
-    - name: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/deployment/push-docker-image-to-harbor-#70') && 'Build and push Docker image to Harbor' || 'Build Docker image' }}
+    - run: echo ${{github.event_name}}
+    - run: echo ${{github.ref}}
+    - run: echo ${{ (github.event_name == 'push' && github.ref == 'refs/heads/deployment/push-docker-image-to-harbor-#70') }}
+    - run: echo ${{ github.event_name == 'push' && github.ref == 'refs/heads/deployment/push-docker-image-to-harbor-#70' }}
+    - run: echo ${{ (github.event_name == 'push' && github.ref == 'refs/heads/deployment/push-docker-image-to-harbor-#70') && 'Build and push Docker image to Harbor' || 'Build Docker image' }}
+    - run: echo ${{ github.event_name == 'push' && github.ref == 'refs/heads/deployment/push-docker-image-to-harbor-#70' && 'Build and push Docker image to Harbor' || 'Build Docker image' }}
+
+    - name: ${{ github.event_name == 'push' && github.ref == 'refs/heads/deployment/push-docker-image-to-harbor-#70' && 'Build and push Docker image to Harbor' || 'Build Docker image' }}
       uses: docker/build-push-action@v2
       with:
         context: .
-        push: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/deployment/push-docker-image-to-harbor-#70') }}
+        push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/deployment/push-docker-image-to-harbor-#70' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -113,6 +113,7 @@ jobs:
       run: nox -s safety
 
   docker:
+    needs: [tests, linting, formatting, safety]
     name: Docker
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -119,3 +119,10 @@ jobs:
     steps:
     - name: Check out repo
       uses: actions/checkout@v2
+
+    - name: Login to Harbor
+      uses: docker/login-action@v1
+      with:
+        registry: harbor.stfc.ac.uk/datagateway
+        username: ${{ secrets.HARBOR_USERNAME }}
+        password: ${{ secrets.HARBOR_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ FROM python:3.6-alpine3.15
 
 # Install the openssh-keygen system package as well as the packages
 # required to build and install the cryptography dependency with pip 
-# RUN apk add --no-cache --virtual build-dependencies \
-#     gcc musl-dev python3-dev libffi-dev openssl-dev cargo openssh-keygen
+RUN apk add --no-cache --virtual build-dependencies \
+    gcc musl-dev python3-dev libffi-dev openssl-dev cargo openssh-keygen
 
 WORKDIR /scigateway-auth
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ FROM python:3.6-alpine3.15
 
 # Install the openssh-keygen system package as well as the packages
 # required to build and install the cryptography dependency with pip 
-RUN apk add --no-cache --virtual build-dependencies \
-    gcc musl-dev python3-dev libffi-dev openssl-dev cargo openssh-keygen
+# RUN apk add --no-cache --virtual build-dependencies \
+#     gcc musl-dev python3-dev libffi-dev openssl-dev cargo openssh-keygen
 
 WORKDIR /scigateway-auth
 


### PR DESCRIPTION
## Description
Unlike the other Harbor related PRs in the DataGateway and SciGateway repos, I have decided to experiment in this PR and make the process for building and pushing the Docker image to Harbor a job in the existing CI workflow instead of a separate workflow. The motivation behind this is so that this job is executed only if all the others succeed as there is no point in building and pushing a Docker image if the other jobs are failing. The workflows are running in parallel and it is only possible to get a workflow to run after a specific one on the default branch (see more [here](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run)). While this may be fine for this repo because the `main` branch is the default branch as there is `develop` branch, it will not work for the other repos that have a `develop` branch which is set to be default.

In summary, the new `docker` job triggers only if all the other jobs in the CI workflow succeed and the things that it does depend on the context. It has been configured to always build the Docker image (not only on pushes to the `k8s-deployment`) but only push the image to Harbor if something is pushed to the `k8s-deployment` branch. The former allows to verify whether the Docker image is successfully building during PRs whereas the latter ensures that the image is not pushed during PRs as the proposed changes may be rejected in the end.

I have tried to test whether the image will be pushed as part of this PR but as it can be seen from the debugging steps in [this](https://github.com/ral-facilities/scigateway-auth/runs/6384909371?check_suite_focus=true) workflow run, the `github.event_name` when something is pushed to a PR is `pull_request` and the `github.ref` was `refs/pulls/74/merge`, making the conditionals in line [146](https://github.com/ral-facilities/scigateway-auth/blob/a7d1b0b51d0fb18fecbae7a40c36237bd3e0ec35/.github/workflows/ci-build.yml#L146) of the workflow file to evaluate to `False`. I am hoping that the image will get pushed to Harbor once this PR is merged into `k8s-deployment`.

I have added TODOs to remind us to change the references of `k8s-deployment` branch to `main` in the CI workflow file once the `k8s-deployment` branch has been merged into `main`.

## Testing Instructions
- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] Review changes to test coverage

## Agile Board Tracking
closes #70