### PR TITLE
Address warnings in Actions CI

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -19,7 +19,7 @@ jobs:
 
     # Setup Python
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
         architecture: x64
@@ -57,7 +57,7 @@ jobs:
     name: Linting
     steps:
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.6'
         architecture: x64
@@ -77,7 +77,7 @@ jobs:
     name: Code Formatting
     steps:
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.6'
         architecture: x64
@@ -97,7 +97,7 @@ jobs:
     name: Dependency Safety
     steps:
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.6'
         architecture: x64

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -26,7 +26,7 @@ jobs:
 
     # Checkout repo
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Prep for the tests
     - name: Create log file
@@ -62,7 +62,7 @@ jobs:
         python-version: '3.6'
         architecture: x64
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install Nox
       run: pip install nox==2020.8.22
@@ -82,7 +82,7 @@ jobs:
         python-version: '3.6'
         architecture: x64
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install Nox
       run: pip install nox==2020.8.22
@@ -102,7 +102,7 @@ jobs:
         python-version: '3.6'
         architecture: x64
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install Nox
       run: pip install nox==2020.8.22

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -50,7 +50,7 @@ jobs:
       run: nox -s tests -- --cov=scigateway_auth --cov-report=xml
     - name: Upload code coverage report
       if: matrix.python-version == '3.6'
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
 
   linting:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
## Description
Addresses the warnings by GitHub Actions in the CI. The warnings can be seen at the bottom of the page [here](https://github.com/ral-facilities/scigateway-auth/actions/runs/3912522882).

## Testing Instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] All warnings should be addressed

## Agile Board Tracking
closes #84 
