### PR TITLE
Fix GitHub Actions Errors

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -42,6 +42,10 @@ jobs:
       run: pip install nox==2020.8.22
     - name: Install Poetry
       run: pip install poetry==1.1.9
+    # This fixes the issue with cachecontrol (https://github.com/psf/cachecontrol/issues/292).
+    # We will not be facing this issue when we upgrade to a newer Poetry version.
+    - name: Install Requests
+      run: pip install 'requests<2.30'
     - name: Install dependencies
       run: poetry install
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -75,6 +75,8 @@ def safety(session):
         # Ignore 51457 as the vulnerability has not yet being fixed
         # Ignore 52322 and 52518 as the latest version of Gitpython does not
         # support python 3.6 which is still used in production
+        # Ignore 53325, 53326, and 54456 as the fixed versions do not support
+        # python 3.6
         session.run(
             "safety",
             "check",
@@ -86,6 +88,12 @@ def safety(session):
             "52322",
             "--ignore",
             "52518",
+            "--ignore",
+            "53325",
+            "--ignore",
+            "53326",
+            "--ignore",
+            "54456",
         )
 
         try:

--- a/noxfile.py
+++ b/noxfile.py
@@ -75,7 +75,7 @@ def safety(session):
         # Ignore 51457 as the vulnerability has not yet being fixed
         # Ignore 52322 and 52518 as the latest version of Gitpython does not
         # support python 3.6 which is still used in production
-        # Ignore 53325, 53326, and 54456 as the fixed versions do not support
+        # Ignore 53325, 53326, 54456, and 55261 as the fixed versions do not support
         # python 3.6
         session.run(
             "safety",
@@ -94,6 +94,8 @@ def safety(session):
             "53326",
             "--ignore",
             "54456",
+            "--ignore",
+            "55261",
         )
 
         try:


### PR DESCRIPTION
## Description
Fixes all the GitHub Action-related errors (https://github.com/ral-facilities/scigateway-auth/actions/runs/5146563191). Also ignores the `werkzeug` vulnerabilities as the fixes for these require Python 3.7 or above.

## Testing Instructions
- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] Review changes to test coverage