### PR TITLE
Pin python docker images to SHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
       interval: daily
       time: "08:00"
       timezone: "Europe/London"
+    ignore:
+      - dependency-name: "python"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,14 @@
 version: 2
 updates:
 
+  # Maintain Dockerfile dependencies
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "08:00"
+      timezone: "Europe/London"
+
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -130,7 +130,7 @@ jobs:
     - name: Login to Harbor
       uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
       with:
-        registry: harbor.stfc.ac.uk/datagateway
+        registry: ${{ secrets.HARBOR_URL }}
         username: ${{ secrets.HARBOR_USERNAME }}
         password: ${{ secrets.HARBOR_TOKEN }}
 
@@ -138,7 +138,7 @@ jobs:
       id: meta
       uses: docker/metadata-action@c4ee3adeed93b1fa6a762f209fb01608c1a22f1e # v4.4.0
       with:
-        images: harbor.stfc.ac.uk/datagateway/scigateway-auth
+        images: ${{ secrets.HARBOR_URL }}/scigateway-auth
 
     - name: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'Build and push Docker image to Harbor' || 'Build Docker image' }}
       uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v4.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile to build and serve scigateway-auth
 
 # Build stage
-FROM python:3.11-alpine3.17 as builder
+FROM python:3.11.8-alpine3.19@sha256:65cb2034c64b4519f1481c552a30ae3fe19f47f3610513b0387dc2e1570080fa as builder
 
 WORKDIR /scigateway-auth-build
 
@@ -16,7 +16,7 @@ RUN --mount=type=cache,target=/root/.cache \
 
 
 # Install & run stage
-FROM python:3.11-alpine3.17
+FROM python:3.11.8-alpine3.19@sha256:65cb2034c64b4519f1481c552a30ae3fe19f47f3610513b0387dc2e1570080fa
 
 WORKDIR /scigateway-auth-run
 


### PR DESCRIPTION
## Description
This PR pins the Python docker images in the Dockerfiles to commit SHAs so that Dependabot can create PRs each time there is a change in the upstream base images that the Python image is set to use as new SHAs are generated on every upstream change. Unfortunately, Dependabot only updates the Python versions but not the OS versions and there is an open issue for this. This means that we will have to do the Alpine version updates manually for now. This PR also configures Dependabot to ignore Python major and minor versions so again we will have to do such Python upgrades manually when we are ready to do that.

## Testing Instructions
- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] Review changes to test coverage