### PR TITLE
Change maintenance PUT endpoints match what SciGateway expects

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2884,21 +2884,21 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.5.0"
+version = "2.6.3"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "dev"]
 files = [
-    {file = "urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc"},
-    {file = "urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760"},
+    {file = "urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"},
+    {file = "urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed"},
 ]
 
 [package.extras]
-brotli = ["brotli (>=1.0.9) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=0.8.0) ; platform_python_implementation != \"CPython\""]
+brotli = ["brotli (>=1.2.0) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=1.2.0.0) ; platform_python_implementation != \"CPython\""]
 h2 = ["h2 (>=4,<5)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
-zstd = ["zstandard (>=0.18.0)"]
+zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 
 [[package]]
 name = "uvicorn"

--- a/scigateway_auth/common/schemas.py
+++ b/scigateway_auth/common/schemas.py
@@ -36,30 +36,9 @@ class MaintenanceStateSchema(BaseModel):
     message: str = Field(description="The maintenance message to be shown")
 
 
-class MaintenancePutRequestSchema(BaseModel):
-    """
-    Schema model for a maintenance `PUT` request.
-    """
-
-    token: str = Field(description="The user's access token")
-    maintenance: MaintenanceStateSchema = Field(description="The maintenance state")
-
-
 class ScheduledMaintenanceStateSchema(MaintenanceStateSchema):
     """
     Schema model for the scheduled maintenance state.
     """
 
     severity: str = Field(description="The severity of the maintenance")
-
-
-class ScheduledMaintenancePutRequestSchema(BaseModel):
-    """
-    Schema model for a scheduled maintenance `PUT` request.
-    """
-
-    token: str = Field(description="The user's access token")
-    scheduled_maintenance: ScheduledMaintenanceStateSchema = Field(
-        alias="scheduledMaintenance",
-        description="The scheduled maintenance state",
-    )


### PR DESCRIPTION
## Description
OG-api  and sg-auth handled the maintenance endpoints slightly differently, and in SciGateway I unified things so everything uses the same maintenance code. I decided the OG way of doing things (passing the token via the Authorization header, and the body is just the new maintenance state) seemed better so I changed SGW to expect that signature. This then aligns scigateway-auth to use the same signature.

## Testing Instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] Review changes to test coverage
- [ ] I have deployed it to the DLS dev stack (ask me for the url) and it's working well

## Agile Board Tracking
Closes #147
